### PR TITLE
Update 404.html to make W3C validator happy

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta http-equiv="refresh" content="0;https://flagicons.lipis.dev" />
+    <meta charset="utf-8">
+    <title>Redirection</title>
+    <meta http-equiv="refresh" content="0; URL=https://flagicons.lipis.dev" />
   </head>
 </html>


### PR DESCRIPTION
<https://validator.w3.org/> reports some errors on the `404.html` page:
- Bad value “0;https://flagicons.lipis.dev” for attribute “content” on element “meta”: Expected a space character, but saw “h” instead.
- Element “head” is missing a required instance of child element “title”.
- The character encoding was not declared.