### PR TITLE
German flag is not rendered correctly on safari

### DIFF
--- a/flags/1x1/de.svg
+++ b/flags/1x1/de.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-de" viewBox="0 0 512 512">
   <path fill="#ffce00" d="M0 341.3h512V512H0z"/>
-  <path d="M0 0h512v170.7H0z"/>
+  <path fill="#000000" d="M0 0h512v170.7H0z"/>
   <path fill="#d00" d="M0 170.7h512v170.6H0z"/>
 </svg>

--- a/flags/1x1/de.svg
+++ b/flags/1x1/de.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-de" viewBox="0 0 512 512">
   <path fill="#ffce00" d="M0 341.3h512V512H0z"/>
-  <path fill="#000000" d="M0 0h512v170.7H0z"/>
+  <path fill="#000" d="M0 0h512v170.7H0z"/>
   <path fill="#d00" d="M0 170.7h512v170.6H0z"/>
 </svg>

--- a/flags/4x3/de.svg
+++ b/flags/4x3/de.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-de" viewBox="0 0 640 480">
   <path fill="#ffce00" d="M0 320h640v160H0z"/>
-  <path d="M0 0h640v160H0z"/>
+  <path fill="#000000" d="M0 0h640v160H0z"/>
   <path fill="#d00" d="M0 160h640v160H0z"/>
 </svg>

--- a/flags/4x3/de.svg
+++ b/flags/4x3/de.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-de" viewBox="0 0 640 480">
   <path fill="#ffce00" d="M0 320h640v160H0z"/>
-  <path fill="#000000" d="M0 0h640v160H0z"/>
+  <path fill="#000" d="M0 0h640v160H0z"/>
   <path fill="#d00" d="M0 160h640v160H0z"/>
 </svg>


### PR DESCRIPTION
German flag is not rendered correctly on safari
![Screenshot 2022-03-14 at 15 19 20](https://user-images.githubusercontent.com/2811609/158191733-d177bee4-57d0-4a28-bc50-6402d92c174c.png)
.