### PR TITLE
Add main to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "6.1.1",
   "author": "Panayiotis Lipiridis <lipiridis@gmail.com>",
   "license": "MIT",
-  "main": "css/flag-icon.css",
+  "main": "css/flag-icons.css",
   "repository": {
     "type": "git",
     "url": "http://github.com/lipis/flag-icons"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "6.1.1",
   "author": "Panayiotis Lipiridis <lipiridis@gmail.com>",
   "license": "MIT",
+  "main": "css/flag-icon.css",
   "repository": {
     "type": "git",
     "url": "http://github.com/lipis/flag-icons"


### PR DESCRIPTION
## what changed

* add `main` attr to `package.json`

## desc

fix `Module not found: Error: Can't resolve 'flag-icons'` in `electron-react-boilerplate` and other projects.

close #945 