### PR TITLE
Make Unknown flag (xx) as the first flag in flag list

### DIFF
--- a/less/flag-icons-list.less
+++ b/less/flag-icons-list.less
@@ -1,3 +1,4 @@
+.flag-icon(xx);
 .flag-icon(ad);
 .flag-icon(ae);
 .flag-icon(af);

--- a/less/flag-icons-more.less
+++ b/less/flag-icons-more.less
@@ -13,4 +13,3 @@
 .flag-icon(ta);
 .flag-icon(un);
 .flag-icon(xk);
-.flag-icon(xx);

--- a/sass/_flag-icons-list.scss
+++ b/sass/_flag-icons-list.scss
@@ -3,6 +3,7 @@
     @include flag-icon($country);
   }
 } @else {
+  @include flag-icon(xx);
   @include flag-icon(ad);
   @include flag-icon(ae);
   @include flag-icon(af);
@@ -269,5 +270,4 @@
   @include flag-icon(ta);
   @include flag-icon(un);
   @include flag-icon(xk);
-  @include flag-icon(xx);
 }


### PR DESCRIPTION
Make Unknown (xx) flag as the first flag so that all other flag icons will have CSS precedence over the Unknown flag.

This will allow all other defined flags to override the Unknown flag. The Unknown flag will only be displayed if it is used against a non-existent flag icon class (eg `fi-vb`). In this scenario, the Unknown flag will become the fallback flag icon since non-existent country flag icon class will not exist.

This PR fixes Issue #940 
Fixes #940