### PR TITLE
CI: Update multiple `actions` & use `nodejs lts` version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,11 +6,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Setup Node.js 14.x
-        uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - name: Setup Node.js LTS
+        uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 'lts/*'
       - name: Install and test
         run: |
           yarn --frozen-lockfile


### PR DESCRIPTION
* Update `actions/checkout` to `v3`
* Rename `Setup Node.js 14.x` to `Setup Node.js LTS`
* Update `actions/setup-node` to `v3`
* Use `nodejs lts` version -> `lts/*`