### PR TITLE
Update Swedish flags

### DIFF
--- a/flags/1x1/se.svg
+++ b/flags/1x1/se.svg
@@ -1,5 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-se" viewBox="0 0 512 512">
-  <path fill="#066aa7" d="M0 0h512v512H0z"/>
-  <path fill="#fecc00" d="M0 204.8h512v102.4H0z"/>
-  <path fill="#fecc00" d="M134 0h102.4v512H134z"/>
+  <path fill="#005293" d="M0 0h512v512H0z"/>
+  <path fill="#fecb00" d="M134 0v204.8H0v102.4h134V512h102.4V307.2H512V204.8H236.4V0H134z"/>
 </svg>

--- a/flags/4x3/se.svg
+++ b/flags/4x3/se.svg
@@ -1,5 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-se" viewBox="0 0 640 480">
-  <path fill="#066aa7" d="M0 0h640v480H0z"/>
-  <path fill="#fecc00" d="M0 192h640v96H0z"/>
-  <path fill="#fecc00" d="M176 0h96v480h-96z"/>
+  <path fill="#005293" d="M0 0h640v480H0z"/>
+  <path fill="#fecb00" d="M176 0v192H0v96h176v192h96V288h368v-96H272V0h-96z"/>
 </svg>


### PR DESCRIPTION
The current Swedish flag in this repo uses incorrect colors. This PR changes the colors to adhere with the [official colors](https://riksdagen.se/sv/dokument-lagar/dokument/svensk-forfattningssamling/forordning-1983826-med-riktlinjer-for_sfs-1983-826).
I also noticed that the cross consisted of two different paths which I found odd.