### PR TITLE
Fix EE flag blue colour

### DIFF
--- a/flags/1x1/ee.svg
+++ b/flags/1x1/ee.svg
@@ -2,6 +2,6 @@
   <g fill-rule="evenodd" stroke-width="1pt" transform="scale(.482 .72)">
     <rect width="1063" height="708.7" rx="0" ry="0"/>
     <rect width="1063" height="236.2" y="475.6" fill="#fff" rx="0" ry="0"/>
-    <path fill="#1291ff" d="M0 0h1063v236.2H0z"/>
+    <path fill="#1791ff" d="M0 0h1063v236.2H0z"/>
   </g>
 </svg>

--- a/flags/4x3/ee.svg
+++ b/flags/4x3/ee.svg
@@ -2,6 +2,6 @@
   <g fill-rule="evenodd" stroke-width="1pt">
     <rect width="640" height="477.9" rx="0" ry="0"/>
     <rect width="640" height="159.3" y="320.7" fill="#fff" rx="0" ry="0"/>
-    <path fill="#1291ff" d="M0 0h640v159.3H0z"/>
+    <path fill="#1791ff" d="M0 0h640v159.3H0z"/>
   </g>
 </svg>


### PR DESCRIPTION
Fixing the incorrect blue colour HEX in ee.svg to be correct.

Source: https://www.riigiteataja.ee/en/eli/530102013068/consolide#:~:text=annex%201%20estonian%20flag

The blue colour tone is 285 C as specified in the international Pantone matching system

In the colours of the triad:
C 91%	CYAN (blue)
M 43%	MAGENTA (purple)
Y 0%	YELLOW (yellow)
B 0%	BLACK (black)