### PR TITLE
Fix blue color in fi.svg

### DIFF
--- a/flags/1x1/fi.svg
+++ b/flags/1x1/fi.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-fi" viewBox="0 0 512 512">
   <path fill="#fff" d="M0 0h512v512H0z"/>
-  <path fill="#003580" d="M0 186.2h512v139.6H0z"/>
-  <path fill="#003580" d="M123.2 0h139.6v512H123.1z"/>
+  <path fill="#002ea2" d="M0 186.2h512v139.6H0z"/>
+  <path fill="#002ea2" d="M123.2 0h139.6v512H123.1z"/>
 </svg>

--- a/flags/4x3/fi.svg
+++ b/flags/4x3/fi.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-fi" viewBox="0 0 640 480">
   <path fill="#fff" d="M0 0h640v480H0z"/>
-  <path fill="#003580" d="M0 174.5h640v131H0z"/>
-  <path fill="#003580" d="M175.5 0h130.9v480h-131z"/>
+  <path fill="#002ea2" d="M0 174.5h640v131H0z"/>
+  <path fill="#002ea2" d="M175.5 0h130.9v480h-131z"/>
 </svg>


### PR DESCRIPTION
Finland flag blue color hex value should be #002ea2, that is if you use the recommended RGB from this source:

https://toolbox.finland.fi/brand-identity-and-guidelines/colour-palette/

Other possible options written in that link are:
> PMS 294
> CMYK 100 / 65 / 0 / 15
> RGB 0 / 46 / 162
> RAL 5010