### PR TITLE
Fixing blurry us flag in Safari

### DIFF
--- a/flags/1x1/us.svg
+++ b/flags/1x1/us.svg
@@ -1,13 +1,9 @@
-<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 512 512">
+<svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-us" viewBox="0 0 512 512">
   <path fill="#bd3d44" d="M0 0h512v512H0"/>
   <path stroke="#fff" stroke-width="40" d="M0 58h512M0 137h512M0 216h512M0 295h512M0 374h512M0 453h512"/>
   <path fill="#192f5d" d="M0 0h390v275H0z"/>
   <marker id="a" markerHeight="30" markerWidth="30">
     <path fill="#fff" d="m15 0 9.3 28.6L0 11h30L5.7 28.6"/>
   </marker>
-  <path id="b" fill="none" marker-mid="url(#a)" d="m0 0 18 11h65 65 65 65 66L51 39h65 65 65 65L0 0"/>
-  <use y="55" href="#b"/>
-  <use y="110" href="#b"/>
-  <use y="166" href="#b"/>
-  <path fill="none" marker-mid="url(#a)" d="m0 0 18 232h65 65 65 65 66L0 0"/>
+  <path fill="none" marker-mid="url(#a)" d="m0 0 18 11h65 65 65 65 66L51 39h65 65 65 65L18 66h65 65 65 65 66L51 94h65 65 65 65L18 121h65 65 65 65 66L51 149h65 65 65 65L18 177h65 65 65 65 66L51 205h65 65 65 65L18 232h65 65 65 65 66L0 0"/>
 </svg>

--- a/flags/1x1/us.svg
+++ b/flags/1x1/us.svg
@@ -1,14 +1,13 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="flag-icons-us" viewBox="0 0 512 512" fill="#fff">
-  <path id="a" fill="#fff" d="M32 12l4 11h11l-9.1 6.7 3.5 10.7-9.4-6.7-8.7 6.7 3.6-10.7-9.5-6.7h11.8z"/>
-  <pattern id="p" patternUnits="userSpaceOnUse" width="65" height="55">
-    <use xlink:href="#a"/>
-  </pattern>
-  <pattern id="l" patternUnits="userSpaceOnUse" width="512" height="78.76">
-    <line stroke="#bd3d44" x2="512" x1="0" stroke-width="42" y1="18" y2="18"/>
-  </pattern>
-  <path d="M0 0h512v512H0"/>
-  <path fill="url(#l)" d="M0 0h512v512H0"/>
+<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 512 512">
+  <path fill="#bd3d44" d="M0 0h512v512H0"/>
+  <path stroke="#fff" stroke-width="40" d="M0 58h512M0 137h512M0 216h512M0 295h512M0 374h512M0 453h512"/>
   <path fill="#192f5d" d="M0 0h390v275H0z"/>
-  <path fill="url(#p)" d="M0 0h390v276H0"/>
-  <path fill="url(#p)" d="M0 0h310v210H0" transform="translate(32 27)"/>
+  <marker id="a" markerHeight="30" markerWidth="30">
+    <path fill="#fff" d="m15 0 9.3 28.6L0 11h30L5.7 28.6"/>
+  </marker>
+  <path id="b" fill="none" marker-mid="url(#a)" d="m0 0 18 11h65 65 65 65 66L51 39h65 65 65 65L0 0"/>
+  <use y="55" href="#b"/>
+  <use y="110" href="#b"/>
+  <use y="166" href="#b"/>
+  <path fill="none" marker-mid="url(#a)" d="m0 0 18 232h65 65 65 65 66L0 0"/>
 </svg>

--- a/flags/4x3/us.svg
+++ b/flags/4x3/us.svg
@@ -1,13 +1,9 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480">
+<svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-us" viewBox="0 0 640 480">
   <path fill="#bd3d44" d="M0 0h640v480H0"/>
   <path stroke="#fff" stroke-width="37" d="M0 55.3h640M0 129h640M0 203h640M0 277h640M0 351h640M0 425h640"/>
   <path fill="#192f5d" d="M0 0h364.8v258.5H0"/>
   <marker id="a" markerHeight="30" markerWidth="30">
     <path fill="#fff" d="m14 0 9 27L0 10h28L5 27z"/>
   </marker>
-  <path id="b" fill="none" marker-mid="url(#a)" d="m0 0 16 11h61 61 61 61 60L47 37h61 61 60 61L0 0"/>
-  <use y="52" href="#b"/>
-  <use y="104" href="#b"/>
-  <use y="155" href="#b"/>
-  <path fill="none" marker-mid="url(#a)" d="m0 0 16 218h61 61 61 61 60L0 0"/>
+  <path fill="none" marker-mid="url(#a)" d="m0 0 16 11h61 61 61 61 60L47 37h61 61 60 61L16 63h61 61 61 61 60L47 89h61 61 60 61L16 115h61 61 61 61 60L47 141h61 61 60 61L16 166h61 61 61 61 60L47 192h61 61 60 61L16 218h61 61 61 61 60L0 0"/>
 </svg>

--- a/flags/4x3/us.svg
+++ b/flags/4x3/us.svg
@@ -1,14 +1,13 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="flag-icons-us" viewBox="0 0 640 480" fill="#fff">
-  <path id="a" fill="#fff" d="m30.4 11 3.4 10.3h10.6l-8.6 6.3 3.3 10.3-8.7-6.4-8.6 6.3L25 27.6l-8.7-6.3h10.9z"/>
-  <pattern id="p" patternUnits="userSpaceOnUse" width="60.8" height="51.55">
-    <use xlink:href="#a"/>
-  </pattern>
-  <pattern id="l" patternUnits="userSpaceOnUse" width="640" height="73.86">
-    <line stroke="#bd3d44" x2="640" stroke-width="38" y1="18" y2="18"/>
-  </pattern>
-  <path d="M0 0h640v480H0"/>
-  <path fill="url(#l)" d="M0 0h640v480H0"/>
-  <path fill="#192f5d" d="M0 0h365v259H0"/>
-  <path fill="url(#p)" d="M0 0h350v250H0"/>
-  <path fill="url(#p)" d="M0 0h310v200H0" transform="translate(30 26)"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 480">
+  <path fill="#bd3d44" d="M0 0h640v480H0"/>
+  <path stroke="#fff" stroke-width="37" d="M0 55.3h640M0 129h640M0 203h640M0 277h640M0 351h640M0 425h640"/>
+  <path fill="#192f5d" d="M0 0h364.8v258.5H0"/>
+  <marker id="a" markerHeight="30" markerWidth="30">
+    <path fill="#fff" d="m14 0 9 27L0 10h28L5 27z"/>
+  </marker>
+  <path id="b" fill="none" marker-mid="url(#a)" d="m0 0 16 11h61 61 61 61 60L47 37h61 61 60 61L0 0"/>
+  <use y="52" href="#b"/>
+  <use y="104" href="#b"/>
+  <use y="155" href="#b"/>
+  <path fill="none" marker-mid="url(#a)" d="m0 0 16 218h61 61 61 61 60L0 0"/>
 </svg>


### PR DESCRIPTION
Fixing a corner case about the US flag in Safari (reproduced in iOS & Mac OS).

When the flag is set to a small size (let's say 20px) and the user zooms in, Safari is not able to render SVG properly. What appens is that the browser creates a raster of the pattern at paint time which is not updated whenever the user zooms.

This new version takes advantage of the [marker SVG element](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/marker) which is has a complete cross browser support and fixes the bug above.

See #1088 