### PR TITLE
Use: actions/setup-python@v4

### DIFF
--- a/.github/workflows/flags.yml
+++ b/.github/workflows/flags.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v4.6.0
+        uses: actions/setup-python@v4
         with:
           python-version: "3.x"
           architecture: "x64"


### PR DESCRIPTION
This will allow to automatically use the latest setup-python v4 action version and will save us time from constantly specifying the more exact latest version.

This will need to be changed again when setup-python v5 action comes out.