### PR TITLE
Fix French flags color to use official ones

### DIFF
--- a/flags/1x1/cp.svg
+++ b/flags/1x1/cp.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-cp" viewBox="0 0 512 512">
   <g fill-rule="evenodd" stroke-width="1pt">
     <path fill="#fff" d="M0 0h512v512H0z"/>
-    <path fill="#002654" d="M0 0h170.7v512H0z"/>
-    <path fill="#ce1126" d="M341.3 0H512v512H341.3z"/>
+    <path fill="#000091" d="M0 0h170.7v512H0z"/>
+    <path fill="#e1000f" d="M341.3 0H512v512H341.3z"/>
   </g>
 </svg>

--- a/flags/1x1/fr.svg
+++ b/flags/1x1/fr.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-fr" viewBox="0 0 512 512">
   <path fill="#fff" d="M0 0h512v512H0z"/>
-  <path fill="#002654" d="M0 0h170.7v512H0z"/>
-  <path fill="#ce1126" d="M341.3 0H512v512H341.3z"/>
+  <path fill="#000091" d="M0 0h170.7v512H0z"/>
+  <path fill="#e1000f" d="M341.3 0H512v512H341.3z"/>
 </svg>

--- a/flags/1x1/gf.svg
+++ b/flags/1x1/gf.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-gf" viewBox="0 0 512 512">
   <path fill="#fff" d="M0 0h512v512H0z"/>
-  <path fill="#002654" d="M0 0h170.7v512H0z"/>
-  <path fill="#ce1126" d="M341.3 0H512v512H341.3z"/>
+  <path fill="#000091" d="M0 0h170.7v512H0z"/>
+  <path fill="#e1000f" d="M341.3 0H512v512H341.3z"/>
 </svg>

--- a/flags/1x1/gp.svg
+++ b/flags/1x1/gp.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-gp" viewBox="0 0 512 512">
   <path fill="#fff" d="M0 0h512v512H0z"/>
-  <path fill="#002654" d="M0 0h170.7v512H0z"/>
-  <path fill="#ce1126" d="M341.3 0H512v512H341.3z"/>
+  <path fill="#000091" d="M0 0h170.7v512H0z"/>
+  <path fill="#e1000f" d="M341.3 0H512v512H341.3z"/>
 </svg>

--- a/flags/1x1/mf.svg
+++ b/flags/1x1/mf.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-mf" viewBox="0 0 512 512">
   <path fill="#fff" d="M0 0h512v512H0z"/>
-  <path fill="#002654" d="M0 0h170.7v512H0z"/>
-  <path fill="#ce1126" d="M341.3 0H512v512H341.3z"/>
+  <path fill="#000091" d="M0 0h170.7v512H0z"/>
+  <path fill="#e1000f" d="M341.3 0H512v512H341.3z"/>
 </svg>

--- a/flags/1x1/pm.svg
+++ b/flags/1x1/pm.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-pm" viewBox="0 0 512 512">
   <path fill="#fff" d="M0 0h512v512H0z"/>
-  <path fill="#002654" d="M0 0h170.7v512H0z"/>
-  <path fill="#ce1126" d="M341.3 0H512v512H341.3z"/>
+  <path fill="#000091" d="M0 0h170.7v512H0z"/>
+  <path fill="#e1000f" d="M341.3 0H512v512H341.3z"/>
 </svg>

--- a/flags/1x1/wf.svg
+++ b/flags/1x1/wf.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-wf" viewBox="0 0 512 512">
   <path fill="#fff" d="M0 0h512v512H0z"/>
-  <path fill="#002654" d="M0 0h170.7v512H0z"/>
-  <path fill="#ce1126" d="M341.3 0H512v512H341.3z"/>
+  <path fill="#000091" d="M0 0h170.7v512H0z"/>
+  <path fill="#e1000f" d="M341.3 0H512v512H341.3z"/>
 </svg>

--- a/flags/1x1/yt.svg
+++ b/flags/1x1/yt.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-yt" viewBox="0 0 512 512">
   <path fill="#fff" d="M0 0h512v512H0z"/>
-  <path fill="#002654" d="M0 0h170.7v512H0z"/>
-  <path fill="#ce1126" d="M341.3 0H512v512H341.3z"/>
+  <path fill="#000091" d="M0 0h170.7v512H0z"/>
+  <path fill="#e1000f" d="M341.3 0H512v512H341.3z"/>
 </svg>

--- a/flags/4x3/bl.svg
+++ b/flags/4x3/bl.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-bl" viewBox="0 0 640 480">
   <path fill="#fff" d="M0 0h640v480H0z"/>
-  <path fill="#002654" d="M0 0h213.3v480H0z"/>
-  <path fill="#ce1126" d="M426.7 0H640v480H426.7z"/>
+  <path fill="#000091" d="M0 0h213.3v480H0z"/>
+  <path fill="#e1000f" d="M426.7 0H640v480H426.7z"/>
 </svg>

--- a/flags/4x3/cp.svg
+++ b/flags/4x3/cp.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-cp" viewBox="0 0 640 480">
   <g fill-rule="evenodd" stroke-width="1pt">
     <path fill="#fff" d="M0 0h640v480H0z"/>
-    <path fill="#002654" d="M0 0h213.3v480H0z"/>
-    <path fill="#ce1126" d="M426.7 0H640v480H426.7z"/>
+    <path fill="#000091" d="M0 0h213.3v480H0z"/>
+    <path fill="#e1000f" d="M426.7 0H640v480H426.7z"/>
   </g>
 </svg>

--- a/flags/4x3/fr.svg
+++ b/flags/4x3/fr.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-fr" viewBox="0 0 640 480">
   <path fill="#fff" d="M0 0h640v480H0z"/>
-  <path fill="#002654" d="M0 0h213.3v480H0z"/>
-  <path fill="#ce1126" d="M426.7 0H640v480H426.7z"/>
+  <path fill="#000091" d="M0 0h213.3v480H0z"/>
+  <path fill="#e1000f" d="M426.7 0H640v480H426.7z"/>
 </svg>

--- a/flags/4x3/gf.svg
+++ b/flags/4x3/gf.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-gf" viewBox="0 0 640 480">
   <path fill="#fff" d="M0 0h640v480H0z"/>
-  <path fill="#002654" d="M0 0h213.3v480H0z"/>
-  <path fill="#ce1126" d="M426.7 0H640v480H426.7z"/>
+  <path fill="#000091" d="M0 0h213.3v480H0z"/>
+  <path fill="#e1000f" d="M426.7 0H640v480H426.7z"/>
 </svg>

--- a/flags/4x3/gp.svg
+++ b/flags/4x3/gp.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-gp" viewBox="0 0 640 480">
   <path fill="#fff" d="M0 0h640v480H0z"/>
-  <path fill="#002654" d="M0 0h213.3v480H0z"/>
-  <path fill="#ce1126" d="M426.7 0H640v480H426.7z"/>
+  <path fill="#000091" d="M0 0h213.3v480H0z"/>
+  <path fill="#e1000f" d="M426.7 0H640v480H426.7z"/>
 </svg>

--- a/flags/4x3/mf.svg
+++ b/flags/4x3/mf.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-mf" viewBox="0 0 640 480">
   <path fill="#fff" d="M0 0h640v480H0z"/>
-  <path fill="#002654" d="M0 0h213.3v480H0z"/>
-  <path fill="#ce1126" d="M426.7 0H640v480H426.7z"/>
+  <path fill="#000091" d="M0 0h213.3v480H0z"/>
+  <path fill="#e1000f" d="M426.7 0H640v480H426.7z"/>
 </svg>

--- a/flags/4x3/pm.svg
+++ b/flags/4x3/pm.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-pm" viewBox="0 0 640 480">
   <path fill="#fff" d="M0 0h640v480H0z"/>
-  <path fill="#002654" d="M0 0h213.3v480H0z"/>
-  <path fill="#ce1126" d="M426.7 0H640v480H426.7z"/>
+  <path fill="#000091" d="M0 0h213.3v480H0z"/>
+  <path fill="#e1000f" d="M426.7 0H640v480H426.7z"/>
 </svg>

--- a/flags/4x3/re.svg
+++ b/flags/4x3/re.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-re" viewBox="0 0 640 480">
   <path fill="#fff" d="M0 0h640v480H0z"/>
-  <path fill="#002654" d="M0 0h213.3v480H0z"/>
-  <path fill="#ce1126" d="M426.7 0H640v480H426.7z"/>
+  <path fill="#000091" d="M0 0h213.3v480H0z"/>
+  <path fill="#e1000f" d="M426.7 0H640v480H426.7z"/>
 </svg>

--- a/flags/4x3/wf.svg
+++ b/flags/4x3/wf.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-wf" viewBox="0 0 640 480">
   <path fill="#fff" d="M0 0h640v480H0z"/>
-  <path fill="#002654" d="M0 0h213.3v480H0z"/>
-  <path fill="#ce1126" d="M426.7 0H640v480H426.7z"/>
+  <path fill="#000091" d="M0 0h213.3v480H0z"/>
+  <path fill="#e1000f" d="M426.7 0H640v480H426.7z"/>
 </svg>

--- a/flags/4x3/yt.svg
+++ b/flags/4x3/yt.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-yt" viewBox="0 0 640 480">
   <path fill="#fff" d="M0 0h640v480H0z"/>
-  <path fill="#002654" d="M0 0h213.3v480H0z"/>
-  <path fill="#ce1126" d="M426.7 0H640v480H426.7z"/>
+  <path fill="#000091" d="M0 0h213.3v480H0z"/>
+  <path fill="#e1000f" d="M426.7 0H640v480H426.7z"/>
 </svg>


### PR DESCRIPTION
Updated french flags colors to follow official guidelines for every gouvernement-linked websites.

https://www.gouvernement.fr/charte/charte-graphique-les-fondamentaux/les-couleurs (sorry did not find any translation for this website)

![image](https://github.com/lipis/flag-icons/assets/37625778/e9328f5f-1502-4a4e-b7eb-a7f7b7d1c1c6)
