### PR TITLE
CI: Update multiple `actions` & make further use of `nodejs lts` version

### DIFF
--- a/.github/workflows/flags.yml
+++ b/.github/workflows/flags.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
           architecture: "x64"

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -6,9 +6,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Node.js LTS
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "lts/*"
       - name: Install and test

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,10 +11,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: "lts/*"
       - run: yarn
       - run: yarn test
 
@@ -22,10 +22,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: "lts/*"
           registry-url: https://registry.npmjs.org/
       - run: yarn
       - run: npm publish


### PR DESCRIPTION
* Update `actions/checkout` to `v4`
* Update `actions/setup-node` to `v4`
* Update `actions/setup-python` to `v5`
* Use "lts/*" in `npm-publish.yml`

Addresses: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/