### PR TITLE
Change Swiss flag to official size

### DIFF
--- a/flags/4x3/ch.svg
+++ b/flags/4x3/ch.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-ch" viewBox="0 0 640 480">
   <g fill-rule="evenodd" stroke-width="1pt">
-    <path fill="red" d="M0 0h640v480H0z"/>
+    <path fill="red" d="M80 0h480v480H80z"/>
     <g fill="#fff">
       <path d="M170 195h300v90H170z"/>
       <path d="M275 90h90v300h-90z"/>


### PR DESCRIPTION
The Swiss flag must be a square as it's described in the official documentation: https://www.fedlex.admin.ch/eli/cc/2015/613/en#art_3

To preserve the proportions of the 4x3 flag, the file has the same size as before, but the flag is squared surrounded by transparent space.

<img width="975" alt="Screenshot 2024-05-09 at 13 46 55" src="https://github.com/lipis/flag-icons/assets/1794673/0c15be89-fcff-467a-8df7-8f16cdba803e">
