### PR TITLE
Fix overlapping paths in at, bg, ee, lu, nl, ru flags

### DIFF
--- a/flags/1x1/at.svg
+++ b/flags/1x1/at.svg
@@ -1,6 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-at" viewBox="0 0 512 512">
-  <g fill-rule="evenodd">
-    <path fill="#fff" d="M512 512H0V0h512z"/>
-    <path fill="#c8102e" d="M512 512H0V341.3h512zm0-341.2H0V.1h512z"/>
-  </g>
+  <path fill="#fff" d="M0 170.7h512v170.6H0z"/>
+  <path fill="#c8102e" d="M0 0h512v170.7H0zm0 341.3h512V512H0z"/>
 </svg>

--- a/flags/1x1/bg.svg
+++ b/flags/1x1/bg.svg
@@ -1,7 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-bg" viewBox="0 0 512 512">
-  <g fill-rule="evenodd" stroke-width="1pt">
-    <path fill="#d62612" d="M0 341.3h512V512H0z"/>
-    <path fill="#fff" d="M0 0h512v170.7H0z"/>
-    <path fill="#00966e" d="M0 170.7h512v170.6H0z"/>
-  </g>
+  <path fill="#fff" d="M0 0h512v170.7H0z"/>
+  <path fill="#00966e" d="M0 170.7h512v170.6H0z"/>
+  <path fill="#d62612" d="M0 341.3h512V512H0z"/>
 </svg>

--- a/flags/1x1/ee.svg
+++ b/flags/1x1/ee.svg
@@ -1,7 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-ee" viewBox="0 0 512 512">
-  <g fill-rule="evenodd" stroke-width="1pt" transform="scale(.482 .72)">
-    <rect width="1063" height="708.7" fill="#000001" rx="0" ry="0"/>
-    <rect width="1063" height="236.2" y="475.6" fill="#fff" rx="0" ry="0"/>
-    <path fill="#1791ff" d="M0 0h1063v236.2H0z"/>
-  </g>
+  <path fill="#1791ff" d="M0 0h512v170.7H0z"/>
+  <path fill="#000001" d="M0 170.7h512v170.6H0z"/>
+  <path fill="#fff" d="M0 341.3h512V512H0z"/>
 </svg>

--- a/flags/1x1/lu.svg
+++ b/flags/1x1/lu.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-lu" viewBox="0 0 512 512">
-  <path fill="#00a1de" d="M0 256h512v256H0z"/>
-  <path fill="#ed2939" d="M0 0h512v256H0z"/>
+  <path fill="#ed2939" d="M0 0h512v170.7H0z"/>
   <path fill="#fff" d="M0 170.7h512v170.6H0z"/>
+  <path fill="#00a1de" d="M0 341.3h512V512H0z"/>
 </svg>

--- a/flags/1x1/nl.svg
+++ b/flags/1x1/nl.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-nl" viewBox="0 0 512 512">
-  <path fill="#21468b" d="M0 0h512v512H0z"/>
-  <path fill="#fff" d="M0 0h512v341.3H0z"/>
   <path fill="#ae1c28" d="M0 0h512v170.7H0z"/>
+  <path fill="#fff" d="M0 170.7h512v170.6H0z"/>
+  <path fill="#21468b" d="M0 341.3h512V512H0z"/>
 </svg>

--- a/flags/1x1/ru.svg
+++ b/flags/1x1/ru.svg
@@ -1,7 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-ru" viewBox="0 0 512 512">
-  <g fill-rule="evenodd" stroke-width="1pt">
-    <path fill="#fff" d="M0 0h512v512H0z"/>
-    <path fill="#0039a6" d="M0 170.7h512V512H0z"/>
-    <path fill="#d52b1e" d="M0 341.3h512V512H0z"/>
-  </g>
+  <path fill="#fff" d="M0 0h512v170.7H0z"/>
+  <path fill="#0039a6" d="M0 170.7h512v170.6H0z"/>
+  <path fill="#d52b1e" d="M0 341.3h512V512H0z"/>
 </svg>

--- a/flags/4x3/at.svg
+++ b/flags/4x3/at.svg
@@ -1,6 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-at" viewBox="0 0 640 480">
-  <g fill-rule="evenodd">
-    <path fill="#fff" d="M640 480H0V0h640z"/>
-    <path fill="#c8102e" d="M640 480H0V320h640zm0-319.9H0V.1h640z"/>
-  </g>
+  <path fill="#fff" d="M0 160h640v160H0z"/>
+  <path fill="#c8102e" d="M0 0h640v160H0zm0 320h640v160H0z"/>
 </svg>

--- a/flags/4x3/bg.svg
+++ b/flags/4x3/bg.svg
@@ -1,7 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-bg" viewBox="0 0 640 480">
-  <g fill-rule="evenodd" stroke-width="1pt">
-    <path fill="#d62612" d="M0 320h640v160H0z"/>
-    <path fill="#fff" d="M0 0h640v160H0z"/>
-    <path fill="#00966e" d="M0 160h640v160H0z"/>
-  </g>
+  <path fill="#fff" d="M0 0h640v160H0z"/>
+  <path fill="#00966e" d="M0 160h640v160H0z"/>
+  <path fill="#d62612" d="M0 320h640v160H0z"/>
 </svg>

--- a/flags/4x3/ee.svg
+++ b/flags/4x3/ee.svg
@@ -1,7 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-ee" viewBox="0 0 640 480">
-  <g fill-rule="evenodd" stroke-width="1pt">
-    <rect width="640" height="477.9" fill="#000001" rx="0" ry="0"/>
-    <rect width="640" height="159.3" y="320.7" fill="#fff" rx="0" ry="0"/>
-    <path fill="#1791ff" d="M0 0h640v159.3H0z"/>
-  </g>
+  <path fill="#1791ff" d="M0 0h640v160H0z"/>
+  <path fill="#000001" d="M0 160h640v160H0z"/>
+  <path fill="#fff" d="M0 320h640v160H0z"/>
 </svg>

--- a/flags/4x3/lu.svg
+++ b/flags/4x3/lu.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-lu" viewBox="0 0 640 480">
-  <path fill="#00a1de" d="M0 240h640v240H0z"/>
-  <path fill="#ed2939" d="M0 0h640v240H0z"/>
+  <path fill="#ed2939" d="M0 0h640v160H0z"/>
   <path fill="#fff" d="M0 160h640v160H0z"/>
+  <path fill="#00a1de" d="M0 320h640v160H0z"/>
 </svg>

--- a/flags/4x3/nl.svg
+++ b/flags/4x3/nl.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-nl" viewBox="0 0 640 480">
-  <path fill="#21468b" d="M0 0h640v480H0z"/>
-  <path fill="#fff" d="M0 0h640v320H0z"/>
   <path fill="#ae1c28" d="M0 0h640v160H0z"/>
+  <path fill="#fff" d="M0 160h640v160H0z"/>
+  <path fill="#21468b" d="M0 320h640v160H0z"/>
 </svg>

--- a/flags/4x3/ru.svg
+++ b/flags/4x3/ru.svg
@@ -1,7 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="flag-icons-ru" viewBox="0 0 640 480">
-  <g fill-rule="evenodd" stroke-width="1pt">
-    <path fill="#fff" d="M0 0h640v480H0z"/>
-    <path fill="#0039a6" d="M0 160h640v320H0z"/>
-    <path fill="#d52b1e" d="M0 320h640v160H0z"/>
-  </g>
+  <path fill="#fff" d="M0 0h640v160H0z"/>
+  <path fill="#0039a6" d="M0 160h640v160H0z"/>
+  <path fill="#d52b1e" d="M0 320h640v160H0z"/>
 </svg>


### PR DESCRIPTION
Hello,

I have been investigating a border-radius issue with the Estonian flag at https://github.com/DOMjudge/domjudge/issues/2537.
As can be seen at https://www.domjudge.org/demoweb/public, there's a faint gray border in the corners of the flag:
![image](https://github.com/lipis/flag-icons/assets/9739541/1e36772e-f4fb-4624-9a94-03d855590d39)
After a lot of digging and thinking this was a bug in all browsers' rendering engines, I came to the conclusion that the flag included a black rectangle spanning the entire background. Changing this rectangle to only span one-third of the flag, appears to fix it :smile: 

| Before | After |
|---|---|
| ![image](https://github.com/lipis/flag-icons/assets/9739541/7a95af9f-1d4f-4c2c-a002-2002130b3644) | ![image](https://github.com/lipis/flag-icons/assets/9739541/e1db5fc4-0b58-4753-aeda-73716a6cff77) |

I've applied the same fix to an arbitrary selection of other flags that use three horizontal bands, because I don't really know a good way to (semi-)automate this and don't feel like fixing all flags manually :stuck_out_tongue: Nonetheless, every little bit helps, and I hope this PR helps as well :slightly_smiling_face: 

<details>
<summary>Quick-and-dirty HTML file that I used to test:</summary>

```html
<!DOCTYPE html>
<html>
    <head>
        <title>Border Radius Test</title>
        <style>
            img {
                border-radius: 80px;
                margin: 40px;
                width: 320px;
            }
        </style>
    </head>
    <body style="background:white">
        <img src="/flags/1x1/at.svg" />
        <img src="/flags/1x1/bg.svg" />
        <img src="/flags/1x1/ee.svg" />
        <img src="/flags/1x1/lu.svg" />
        <img src="/flags/1x1/nl.svg" />
        <img src="/flags/1x1/ru.svg" />
        <br />
        <img src="/flags/4x3/at.svg" />
        <img src="/flags/4x3/bg.svg" />
        <img src="/flags/4x3/ee.svg" />
        <img src="/flags/4x3/lu.svg" />
        <img src="/flags/4x3/nl.svg" />
        <img src="/flags/4x3/ru.svg" />
    </body>
</html>
```

Place this file in the repo's root and run `python3 -m http.server` to test. Change `background:white` to something else to make sure that the white bars are actually there.
</details>

