### PR TITLE
Update CDN URL to latest version (7.3.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ or use CDN:
 ```html
 <link
   rel="stylesheet"
-  href="https://cdn.jsdelivr.net/gh/lipis/flag-icons@7.2.3/css/flag-icons.min.css"
+  href="https://cdn.jsdelivr.net/gh/lipis/flag-icons@7.3.2/css/flag-icons.min.css"
 />
 ```
 


### PR DESCRIPTION
updated docs CDN ref to v7.3.2 - keeps new users on latest stable