### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-.DS_Store
 bower_components
 main
 node_modules
 temp
 update
+.DS_Store


### PR DESCRIPTION
This PR simply adds a `.DS_Store` line to the `.gitignore` file so that those of us developing on Mac don't push those files into the repo.
